### PR TITLE
Convert the serial number from hex string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-core",
+ "hex",
  "humantime",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ futures-core = "0.3"
 udev = { git="https://github.com/jprendes/udev-rs.git", features = ["send"] }
 bollard = "0.13"
 futures = "0.3"
+hex = "0.4.3"

--- a/src/cli/device.rs
+++ b/src/cli/device.rs
@@ -15,8 +15,12 @@ pub enum DeviceType {
     Devnode(PathBuf),
 }
 
+fn is_hex(val: &str) -> bool {
+    val.chars().all(|c| c.is_ascii_hexdigit())
+}
+
 fn is_hex4(val: &str) -> bool {
-    val.len() == 4 && val.chars().all(|c| c.is_ascii_hexdigit())
+    val.len() == 4 && is_hex(val)
 }
 
 fn is_alphanum(val: &str) -> bool {
@@ -75,7 +79,13 @@ impl FromStr for Device {
 
                 let vid = vid.to_ascii_lowercase();
                 let pid = pid.map(|s| s.to_ascii_lowercase());
-                let serial = serial.map(|s| s.to_owned());
+                let serial = serial.map(|s| {
+                    if is_hex(s) {
+                        String::from_utf8(hex::decode(s).unwrap()).unwrap()
+                    } else {
+                        s.to_owned()
+                    }
+                });
 
                 DeviceType::Usb(vid, pid, serial)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ enum Action {
         ///   l: level {n}
         ///   t: timestamp {n}
         ///   m/p: module name/path {n}
-        /// 
+        ///
         log_format: LogFormat,
 
         #[arg(trailing_var_arg = true, id = "ARGS")]
@@ -187,8 +187,7 @@ async fn hotplug_main() -> Result<ExitCode> {
             let _ = container.pipe_signals();
 
             let hub_path = root_device.hub()?.syspath().to_owned();
-            let hotplug_stream =
-                run_hotplug(root_device, symlink, container.clone(), verbosity);
+            let hotplug_stream = run_hotplug(root_device, symlink, container.clone(), verbosity);
             let container_stream = {
                 let container = container.clone();
                 async_stream::try_stream! {


### PR DESCRIPTION
The Chipwhisperer board serial number is encoded as a hex string, this commit convert it to an utf8 string to make is more human readable.