### PR TITLE
Perform I/O in mnt namespace directly instead of calling into docker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tokio-util = { version = "0.7", features = ["full"] }
 async-stream = "0.3"
 udev = "0.8"
 bollard = "0.16"
-rustix = { version = "0.38", features = ["fs", "stdio", "termios", "process"] }
+rustix = { version = "0.38", features = ["fs", "stdio", "termios", "process", "thread"] }
 bitflags = "2"
 aya = { git = "https://github.com/aya-rs/aya.git" }
 

--- a/src/docker/container.rs
+++ b/src/docker/container.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 
-use super::{IoStream, IoStreamSource};
+use super::IoStream;
 use crate::cgroup::{
     Access, DeviceAccessController, DeviceAccessControllerV1, DeviceAccessControllerV2, DeviceType,
 };
@@ -122,7 +122,7 @@ impl Container {
         Ok(IoStream {
             output: response.output,
             input: response.input,
-            source: IoStreamSource::Container(self.id.clone()),
+            id: self.id.clone(),
             docker: self.docker.clone(),
         })
     }

--- a/src/docker/docker.rs
+++ b/src/docker/docker.rs
@@ -12,16 +12,12 @@ impl Docker {
     pub async fn get<T: AsRef<str>>(&self, name: T) -> Result<Container> {
         let response = self.0.inspect_container(name.as_ref(), None).await?;
         let id = response.id.context("Failed to obtain container ID")?;
-        let config = response
-            .config
-            .context("Failed to obtain container config")?;
-        let user = config.user.context("Failed to obtain container user")?;
         let pid = response
             .state
             .context("Failed to obtain container state")?
             .pid
             .context("Failed to obtain container pid")?;
-        Container::new(&self.0, id, pid.try_into()?, user)
+        Container::new(&self.0, id, pid.try_into()?).await
     }
 
     pub async fn run<U: AsRef<str>, T: AsRef<[U]>>(&self, args: T) -> Result<Container> {

--- a/src/docker/docker.rs
+++ b/src/docker/docker.rs
@@ -16,7 +16,12 @@ impl Docker {
             .config
             .context("Failed to obtain container config")?;
         let user = config.user.context("Failed to obtain container user")?;
-        Container::new(&self.0, id, user)
+        let pid = response
+            .state
+            .context("Failed to obtain container state")?
+            .pid
+            .context("Failed to obtain container pid")?;
+        Container::new(&self.0, id, pid.try_into()?, user)
     }
 
     pub async fn run<U: AsRef<str>, T: AsRef<[U]>>(&self, args: T) -> Result<Container> {

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -5,5 +5,3 @@ mod iostream;
 pub use container::Container;
 pub use docker::Docker;
 pub use iostream::IoStream;
-
-use iostream::IoStreamSource;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,3 @@
 pub mod escape;
+pub mod namespace;
 pub mod tty_mode_guard;

--- a/src/util/namespace.rs
+++ b/src/util/namespace.rs
@@ -1,0 +1,42 @@
+use std::fs::File;
+use std::os::fd::AsFd;
+
+use anyhow::Result;
+use rustix::process::Pid;
+use rustix::thread::{LinkNameSpaceType, UnshareFlags};
+
+pub struct MntNamespace {
+    fd: File,
+}
+
+impl MntNamespace {
+    /// Open the mount namespace of a process.
+    pub fn of_pid(pid: Pid) -> Result<MntNamespace> {
+        let path = format!("/proc/{}/ns/mnt", pid.as_raw_nonzero());
+        let fd = File::open(path)?;
+        Ok(MntNamespace { fd })
+    }
+
+    /// Enter the mount namespace.
+    pub fn enter<T: Send, F: FnOnce() -> T + Send>(&self, f: F) -> Result<T> {
+        // To avoid messing with rest of the process, we do everything in a new thread.
+        // Use scoped thread to avoid 'static bound (we need to access fd).
+        std::thread::scope(|scope| {
+            scope
+                .spawn(|| -> Result<T> {
+                    // Unshare FS for this specific thread so we can switch to another namespace.
+                    // Not doing this will cause EINVAL when switching to namespaces.
+                    rustix::thread::unshare(UnshareFlags::FS)?;
+
+                    // Switch this particular thread to the container's mount namespace.
+                    rustix::thread::move_into_link_name_space(
+                        self.fd.as_fd(),
+                        Some(LinkNameSpaceType::Mount),
+                    )?;
+                    Ok(f())
+                })
+                .join()
+                .map_err(|_| anyhow::anyhow!("work thread panicked"))?
+        })
+    }
+}


### PR DESCRIPTION
The current approach requires the binaries to be available inside the container. Change to perform I/O in the container's mount namespace directly. This is more robust and less expensive.

Similarly docker API is avoided for killing the container process (since we can easily get its PID and kill it directly)