### PR TITLE
Support containers launched with user namespace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 async-stream = "0.3"
 udev = "0.8"
-rustix = { version = "0.38", features = ["fs", "stdio", "process", "thread", "pipe"] }
+rustix = { version = "0.38", features = ["fs", "stdio", "process", "thread", "pipe", "mount"] }
 bitflags = "2"
 once_cell = "1"
 humantime = "2"

--- a/shell.nix
+++ b/shell.nix
@@ -8,5 +8,8 @@ pkgs.mkShell {
 
     # For llvm-objdump
     llvmPackages.bintools
+
+    # To aid testing
+    runc
   ];
 }

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -7,8 +7,8 @@ use std::mem::ManuallyDrop;
 use std::path::{Path, PathBuf};
 
 // The numerical representation below needs to match BPF_DEVCG constants.
-#[allow(unused)]
 #[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeviceType {
     Block = 1,
     Character = 2,

--- a/src/hotplug/mod.rs
+++ b/src/hotplug/mod.rs
@@ -70,8 +70,12 @@ impl HotPlug {
                     .filter_map(|dev| dev.matches(&device))
                     .collect();
 
-                self.container.device(devnode.devnum, Access::all()).await?;
-                self.container.mknod(&devnode.path, devnode.devnum).await?;
+                self.container
+                    .device(devnode.ty, devnode.devnum, Access::all())
+                    .await?;
+                self.container
+                    .mknod(&devnode.path, devnode.ty, devnode.devnum)
+                    .await?;
                 for symlink in &symlinks {
                     self.container.symlink(&devnode.path, symlink).await?;
                 }
@@ -89,7 +93,7 @@ impl HotPlug {
 
                 let devnode = device.devnode().unwrap();
                 self.container
-                    .device(devnode.devnum, Access::empty())
+                    .device(devnode.ty, devnode.devnum, Access::empty())
                     .await?;
                 self.container.rm(&devnode.path).await?;
                 for symlink in &device.symlinks {

--- a/src/util/namespace.rs
+++ b/src/util/namespace.rs
@@ -1,20 +1,70 @@
 use std::fs::File;
 use std::os::fd::AsFd;
+use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use rustix::fs::{Gid, Uid};
 use rustix::process::Pid;
-use rustix::thread::{LinkNameSpaceType, UnshareFlags};
+use rustix::thread::{CapabilitiesSecureBits, LinkNameSpaceType, UnshareFlags};
+
+pub struct IdMap {
+    map: Vec<(u32, u32, u32)>,
+}
+
+impl IdMap {
+    fn read(path: &Path) -> Result<Self> {
+        Self::parse(&std::fs::read_to_string(path)?)
+    }
+
+    fn parse(content: &str) -> Result<Self> {
+        let mut map = Vec::new();
+        for line in content.lines() {
+            let mut words = line.split_ascii_whitespace();
+            let inside = words.next().context("unexpected id_map")?.parse()?;
+            let outside = words.next().context("unexpected id_map")?.parse()?;
+            let count = words.next().context("unexpected id_map")?.parse()?;
+            map.push((inside, outside, count));
+        }
+        Ok(Self { map })
+    }
+
+    fn translate(&self, id: u32) -> Option<u32> {
+        for &(inside, outside, count) in self.map.iter() {
+            if (inside..inside.checked_add(count)?).contains(&id) {
+                return (id - inside).checked_add(outside);
+            }
+        }
+        None
+    }
+}
 
 pub struct MntNamespace {
-    fd: File,
+    mnt_fd: File,
+    uid_map: IdMap,
+    gid_map: IdMap,
 }
 
 impl MntNamespace {
     /// Open the mount namespace of a process.
     pub fn of_pid(pid: Pid) -> Result<MntNamespace> {
-        let path = format!("/proc/{}/ns/mnt", pid.as_raw_nonzero());
-        let fd = File::open(path)?;
-        Ok(MntNamespace { fd })
+        let mnt_fd = File::open(format!("/proc/{}/ns/mnt", pid.as_raw_nonzero()))?;
+        let uid_map = IdMap::read(format!("/proc/{}/uid_map", pid.as_raw_nonzero()).as_ref())?;
+        let gid_map = IdMap::read(format!("/proc/{}/gid_map", pid.as_raw_nonzero()).as_ref())?;
+        Ok(MntNamespace {
+            mnt_fd,
+            uid_map,
+            gid_map,
+        })
+    }
+
+    /// Translate user ID into a UID in the namespace.
+    pub fn uid(&self, uid: u32) -> Result<u32> {
+        Ok(self.uid_map.translate(uid).context("UID overflows")?)
+    }
+
+    /// Translate group ID into a GID in the namespace.
+    pub fn gid(&self, gid: u32) -> Result<u32> {
+        Ok(self.gid_map.translate(gid).context("GID overflows")?)
     }
 
     /// Enter the mount namespace.
@@ -30,9 +80,35 @@ impl MntNamespace {
 
                     // Switch this particular thread to the container's mount namespace.
                     rustix::thread::move_into_link_name_space(
-                        self.fd.as_fd(),
+                        self.mnt_fd.as_fd(),
                         Some(LinkNameSpaceType::Mount),
                     )?;
+
+                    // If user namespace is used, we must act like the root user *inside*
+                    // namespace to be able to create files properly (otherwise EOVERFLOW
+                    // will be returned when creating file).
+                    //
+                    // Entering the user namespace turns out to be problematic.
+                    // The reason seems to be this line [1]:
+                    // which means `CAP_MKNOD` capability of the *init* namespace is needed.
+                    // However task's associated security context is all relative to its current
+                    // user namespace [2], so once you enter a user namespace there's no way of getting
+                    // back `CAP_MKNOD` of the init namespace anymore.
+                    // (Yes this means that even if CAP_MKNOD is granted to the container, you cannot
+                    // create device nodes within it.)
+                    //
+                    // [1]: https://elixir.bootlin.com/linux/v6.11.1/source/fs/namei.c#L4073
+                    // [2]: https://elixir.bootlin.com/linux/v6.11.1/source/include/linux/cred.h#L111
+
+                    // By default `setuid` will drop capabilities when transitioning from root
+                    // to non-root user. This bit prevents it so our code still have superpower.
+                    rustix::thread::set_capabilities_secure_bits(
+                        CapabilitiesSecureBits::NO_SETUID_FIXUP,
+                    )?;
+
+                    rustix::thread::set_thread_uid(unsafe { Uid::from_raw(self.uid(0)?) })?;
+                    rustix::thread::set_thread_gid(unsafe { Gid::from_raw(self.gid(0)?) })?;
+
                     Ok(f())
                 })
                 .join()

--- a/src/util/namespace.rs
+++ b/src/util/namespace.rs
@@ -57,6 +57,11 @@ impl MntNamespace {
         })
     }
 
+    /// Check if we're in an user namespace.
+    pub fn in_user_ns(&self) -> bool {
+        !(self.uid_map.map == &[(0, 0, u32::MAX)] && self.gid_map.map == &[(0, 0, u32::MAX)])
+    }
+
     /// Translate user ID into a UID in the namespace.
     pub fn uid(&self, uid: u32) -> Result<u32> {
         Ok(self.uid_map.translate(uid).context("UID overflows")?)


### PR DESCRIPTION
By default Docker/k8s run the root user inside the container as the root user of the host. This means that there's syscall filtering and path masking necessary to prevent the root of inside container from escaping. This negatively affects Nix sandboxing inside containers, because syscalls it rely on are blocked.

User namespaces also the root user inside a container to be mapped to a non-root user -- this would make all filtering and masking unnecessary (and is what rootless containers use). When we enable userns, we can then disable filtering/masking without compromising security, and then enable Nix sandbox.